### PR TITLE
[packaging] Don't obsolete/replace yet. Contributes to JB#13775

### DIFF
--- a/rpm/qt5-qpa-hwcomposer-plugin-boston.spec
+++ b/rpm/qt5-qpa-hwcomposer-plugin-boston.spec
@@ -28,8 +28,9 @@ BuildRequires:  wayland-devel
 BuildRequires:  pkgconfig(udev)
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(mtdev)
-Obsoletes: qt5-eglfs-qcom-hwcomposer-plugin <= 5.1.0+git15
-Provides: qt5-eglfs-qcom-hwcomposer-plugin > 5.1.0+git15
+# Commented out for now to not break downgrades
+#Obsoletes: qt5-eglfs-qcom-hwcomposer-plugin <= 5.1.0+git15
+#Provides: qt5-eglfs-qcom-hwcomposer-plugin > 5.1.0+git15
 
 %description
 This package contains a Qt 5 QPA plugin using libhybris' Droid

--- a/rpm/qt5-qpa-hwcomposer-plugin-sbj.spec
+++ b/rpm/qt5-qpa-hwcomposer-plugin-sbj.spec
@@ -28,8 +28,9 @@ BuildRequires:  wayland-devel
 BuildRequires:  pkgconfig(udev)
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(mtdev)
-Obsoletes: qt5-eglfs-qcom-hwcomposer-plugin <= 5.1.0+git15
-Provides: qt5-eglfs-qcom-hwcomposer-plugin > 5.1.0+git15
+# Commented out for now to not break downgrades
+#Obsoletes: qt5-eglfs-qcom-hwcomposer-plugin <= 5.1.0+git15
+#Provides: qt5-eglfs-qcom-hwcomposer-plugin > 5.1.0+git15
 
 %description
 This package contains a Qt 5 QPA plugin using libhybris' Droid

--- a/rpm/qt5-qpa-hwcomposer-plugin.spec.in
+++ b/rpm/qt5-qpa-hwcomposer-plugin.spec.in
@@ -28,8 +28,9 @@ BuildRequires:  wayland-devel
 BuildRequires:  pkgconfig(udev)
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(mtdev)
-Obsoletes: qt5-eglfs-qcom-hwcomposer-plugin <= 5.1.0+git15
-Provides: qt5-eglfs-qcom-hwcomposer-plugin > 5.1.0+git15
+# Commented out for now to not break downgrades
+#Obsoletes: qt5-eglfs-qcom-hwcomposer-plugin <= 5.1.0+git15
+#Provides: qt5-eglfs-qcom-hwcomposer-plugin > 5.1.0+git15
 
 %description
 This package contains a Qt 5 QPA plugin using libhybris' Droid


### PR DESCRIPTION
This allows downgrades to not break because of a missing eglfs plugin.
