### PR TITLE
Don't automagically create evdev handlers for autodetection.

### DIFF
--- a/hwcomposer/qeglfsintegration.cpp
+++ b/hwcomposer/qeglfsintegration.cpp
@@ -52,12 +52,6 @@
 #include <QtPlatformSupport/private/qeglplatformcontext_p.h>
 #include <QtPlatformSupport/private/qeglpbuffer_p.h>
 
-#if !defined(QT_NO_EVDEV) && (!defined(Q_OS_ANDROID) || defined(Q_OS_ANDROID_NO_SDK))
-#include <QtPlatformSupport/private/qevdevmousemanager_p.h>
-#include <QtPlatformSupport/private/qevdevkeyboardmanager_p.h>
-#include <QtPlatformSupport/private/qevdevtouch_p.h>
-#endif
-
 #include <qpa/qplatformwindow.h>
 #include <QtGui/QSurfaceFormat>
 #include <QtGui/QOpenGLContext>
@@ -80,12 +74,6 @@ QEglFSIntegration::QEglFSIntegration()
 {
 #if QT_VERSION < QT_VERSION_CHECK(5, 2, 0)
     QGuiApplicationPrivate::instance()->setEventDispatcher(mEventDispatcher);
-#endif
-
-#if !defined(QT_NO_EVDEV) && (!defined(Q_OS_ANDROID) || defined(Q_OS_ANDROID_NO_SDK))
-    new QEvdevKeyboardManager(QLatin1String("EvdevKeyboard"), QString() /* spec */, this);
-    new QEvdevMouseManager(QLatin1String("EvdevMouse"), QString() /* spec */, this);
-    new QEvdevTouchScreenHandlerThread(QString() /* spec */, this);
 #endif
 
     mHwc = new HwComposerContext();


### PR DESCRIPTION
Require them to be loaded with -plugin.

This prevents auto-detection (which was not opt-out) from conflicting with the
actual settings on device, which may sometimes cause issues ranging from
useless instantiation to double processing of events which is definitely not
desired.
