### PR TITLE
Fix return value and only set m_swapIntervalConfigured if eglSwapInterval() succeeds

### DIFF
--- a/hwcomposer/qeglfscontext.cpp
+++ b/hwcomposer/qeglfscontext.cpp
@@ -69,7 +69,10 @@ bool QEglFSContext::makeCurrent(QPlatformSurface *surface)
             if (!ok)
                 swapInterval = 1;
         }
-        eglSwapInterval(eglDisplay(), swapInterval);
+        if (eglSwapInterval(eglDisplay(), swapInterval) != EGL_TRUE) {
+            // Reset and try again later if we couldn't set the swap interval
+            m_swapIntervalConfigured = false;
+        }
     }
 
     return current;


### PR DESCRIPTION
The patch from https://github.com/mer-hybris/qt5-qpa-hwcomposer-plugin/pull/18 introduced a bug that doesn't return a value in the `makeCurrent()` function anymore. Also, set `m_swapIntervalConfigured` to `false` in case `eglSwapInterval()` fails, so we can try setting the swap interval again at next try.

Hopefully this doesn't result in a situation where it tries to set the swap interval, but always fails, so it tries to set the swap interval on every `makeCurrent()`. If this is an issue, we could introduce some maximum number of tries and stop trying to set the interval if it still fails after that.
