### PR TITLE
tearing fixed in cm nightly, reverting relevant morphis' commit

### DIFF
--- a/hwcomposer/hwcomposer_backend.cpp
+++ b/hwcomposer/hwcomposer_backend.cpp
@@ -139,7 +139,7 @@ HwComposerBackend::create()
 #ifdef HWC_DEVICE_API_VERSION_1_3
         case HWC_DEVICE_API_VERSION_1_3:
             /* Do not use virtual displays */
-            return new HwComposerBackend_v11(hwc_module, hwc_device, HWC_NUM_DISPLAY_TYPES);
+            return new HwComposerBackend_v11(hwc_module, hwc_device, HWC_NUM_PHYSICAL_DISPLAY_TYPES);
             break;
 #endif /* HWC_DEVICE_API_VERSION_1_3 */
 #endif /* HWC_PLUGIN_HAVE_HWCOMPOSER1_API */


### PR DESCRIPTION
@siteshwar's patch accepted by CM: http://review.cyanogenmod.org/#/c/67489/
Landed in nightly: http://mirror.slc.cyanogenmod.org/jenkins/77012/cm-11-20140723-NIGHTLY-hammerhead.zip
This qpa-hwc has been tested - no tearing encountered with cm above
