### PR TITLE
Fix too many arguments for format warning

### DIFF
--- a/hwcomposer/hwcomposer_backend.h
+++ b/hwcomposer/hwcomposer_backend.h
@@ -65,7 +65,7 @@
 
 // Evaluate "x", if it is NULL, exit with a fatal error
 #define HWC_PLUGIN_FATAL(x) \
-    qFatal("QPA-HWC: %s", x, __func__)
+    qFatal("QPA-HWC: %s in %s", x, __func__)
 
 // Evaluate "x", if it is NULL, exit with a fatal error
 #define HWC_PLUGIN_ASSERT_NOT_NULL(x) \

--- a/hwcomposer/main.cpp
+++ b/hwcomposer/main.cpp
@@ -47,11 +47,8 @@ QT_BEGIN_NAMESPACE
 class QEglFSIntegrationPlugin : public QPlatformIntegrationPlugin
 {
     Q_OBJECT
-#if QT_VERSION < QT_VERSION_CHECK(5, 2, 0)
-    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QPA.QPlatformIntegrationFactoryInterface.5.1" FILE "hwcomposer.json")
-#else
-    Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QPA.QPlatformIntegrationFactoryInterface.5.2" FILE "hwcomposer.json")
-#endif
+    Q_PLUGIN_METADATA(IID QPlatformIntegrationFactoryInterface_iid FILE "hwcomposer.json")
+
 public:
     QPlatformIntegration *create(const QString&, const QStringList&);
 };


### PR DESCRIPTION
Minor fix for HWC_PLUGIN_FATAL(x), make the __func__ argument
really show by this macro.

Signed-off-by: Yen-Chin Lee <coldnew.tw@gmail.com>