### PR TITLE
[hwcomposer] Move hwcomposer to its own thread.

### DIFF
--- a/hwcomposer/hwcomposer_backend.cpp
+++ b/hwcomposer/hwcomposer_backend.cpp
@@ -46,6 +46,7 @@
 #include "hwcomposer_backend_v10.h"
 #include "hwcomposer_backend_v11.h"
 
+Q_LOGGING_CATEGORY(QPA_LOG_HWC, "qpa.hwc")
 
 HwComposerBackend::HwComposerBackend(hw_module_t *hwc_module)
     : hwc_module(hwc_module)

--- a/hwcomposer/hwcomposer_backend.h
+++ b/hwcomposer/hwcomposer_backend.h
@@ -51,7 +51,9 @@
 #include <EGL/eglext.h>
 
 #include <qdebug.h>
+#include <qloggingcategory.h>
 
+Q_DECLARE_LOGGING_CATEGORY(QPA_LOG_HWC)
 
 // Evaluate "x", if it doesn't return zero, print a warning
 #define HWC_PLUGIN_EXPECT_ZERO(x) \

--- a/hwcomposer/hwcomposer_backend_v11.cpp
+++ b/hwcomposer/hwcomposer_backend_v11.cpp
@@ -1,7 +1,8 @@
 /****************************************************************************
 **
-** Copyright (C) 2013 Jolla Ltd.
+** Copyright (C) 2013, 2015 Jolla Ltd.
 ** Contact: Thomas Perl <thomas.perl@jolla.com>
+** Contact: Gunnar Sletta <gunnar.sletta@jollamobile.com>
 **
 ** This file is part of the hwcomposer plugin.
 **
@@ -44,170 +45,113 @@
 #include "hwcomposer_backend_v11.h"
 #include <stdio.h>
 
+#include <QThread>
+#include <QMutex>
+#include <QWaitCondition>
+#include <QEvent>
+#include <QCoreApplication>
+
 #ifdef HWC_PLUGIN_HAVE_HWCOMPOSER1_API
 
-class HWComposer : public HWComposerNativeWindow
+class HWC11Thread;
+
+
+class HWC11WindowSurface : public HWComposerNativeWindow
 {
-    private:
-        hwc_layer_1_t *fblayer;
-        hwc_composer_device_1_t *hwcdevice;
-        hwc_display_contents_1_t **mlist;
-        int num_displays;
-    protected:
-        void present(HWComposerNativeWindowBuffer *buffer);
+protected:
+    void present(HWComposerNativeWindowBuffer *buffer);
 
-    public:
+public:
+    unsigned int width() const { return HWComposerNativeWindow::width(); }
+    unsigned int height() const { return HWComposerNativeWindow::height(); }
+    HWC11WindowSurface(unsigned int width, unsigned int height, unsigned int format);
 
-    HWComposer(unsigned int width, unsigned int height, unsigned int format,
-            hwc_composer_device_1_t *device, hwc_display_contents_1_t **mList,
-            hwc_layer_1_t *layer, int num_displays);
-    void set();
+    HWComposerNativeWindowBuffer *buffer;
+    HWC11Thread *thread;
 };
 
-HWComposer::HWComposer(unsigned int width, unsigned int height, unsigned int format,
-        hwc_composer_device_1_t *device, hwc_display_contents_1_t **mList,
-        hwc_layer_1_t *layer, int num_displays)
+
+class HWC11Thread : public QThread
+{
+public:
+    enum Action {
+        InitializeAction = QEvent::User,
+        CleanupAction,
+        BufferReadyAction,
+        DisplaySleepAction,
+        DisplayWakeAction,
+    };
+
+    HWC11Thread();
+
+    void swap();
+    void initialize();
+    void cleanup();
+    void post(Action a) { QCoreApplication::postEvent(this, new QEvent((QEvent::Type) a)); }
+
+    bool event(QEvent *e);
+
+    inline void lock() { mutex.lock(); }
+    inline void unlock() { mutex.unlock(); }
+    inline void wait() { condition.wait(&mutex); }
+    inline void wake() { condition.wakeOne(); }
+
+    HWC11WindowSurface *windowSurface;
+    HWComposerNativeWindowBuffer *buffer;
+    hwc_composer_device_1_t *device;
+    hwc_display_contents_1_t *eglSurfaceList;
+    QMutex mutex;
+    QWaitCondition condition;
+    int frameFence;
+};
+
+
+HWC11WindowSurface::HWC11WindowSurface(unsigned int width, unsigned int height, unsigned int format)
     : HWComposerNativeWindow(width, height, format)
-    , fblayer(layer)
-    , hwcdevice(device)
-    , mlist(mList)
-    , num_displays(num_displays)
+    , buffer(0)
+    , thread(0)
 {
 }
 
-void HWComposer::present(HWComposerNativeWindowBuffer *buffer)
+/* Sets the buffer as the current front buffer to be displayed through the
+   HWC. The HWC will pick up the buffer and set it to 0.
+
+   If there already is a buffer pending for display, this function will block
+   until the current buffer has been picked up. As HwcWindowSurfaceNativeWindow
+   has two buffers by default, this allows us to queue up one buffer before
+   rendering is blocked on the EGL render thread.
+ */
+void HWC11WindowSurface::present(HWComposerNativeWindowBuffer *b)
 {
-    int oldretire = mlist[0]->retireFenceFd;
-    mlist[0]->retireFenceFd = -1;
-    mlist[0]->numHwLayers = 1;
-    mlist[0]->hwLayers[0].compositionType = HWC_FRAMEBUFFER_TARGET;
-    mlist[0]->hwLayers[0].handle = buffer->handle;
-    mlist[0]->hwLayers[0].acquireFenceFd = getFenceBufferFd(buffer);
-    mlist[0]->hwLayers[0].releaseFenceFd = -1;
-
-    int err = hwcdevice->prepare(hwcdevice, num_displays, mlist);
-    HWC_PLUGIN_EXPECT_ZERO(err);
-    err = hwcdevice->set(hwcdevice, num_displays, mlist);
-    HWC_PLUGIN_EXPECT_ZERO(err);
-    setFenceBufferFd(buffer, mlist[0]->hwLayers[0].releaseFenceFd);
-
-    if (oldretire != -1)
-    {
-        sync_wait(oldretire, -1);
-        close(oldretire);
+    qCDebug(QPA_LOG_HWC, "present: %p (%p), current=%p", b, b->handle, buffer);
+    thread->lock();
+    if (buffer != 0) {
+        qCDebug(QPA_LOG_HWC, " - buffer already pending, waiting for hwc to pick it up");
+        thread->wait();
+        qCDebug(QPA_LOG_HWC, " - buffer picked up, setting front buffer %p, current=%p", b, buffer);
     }
+    buffer = b;
+    thread->post(HWC11Thread::BufferReadyAction);
+    thread->unlock();
 }
 
-static const uint32_t DISPLAY_ATTRIBUTES[] = {
-    HWC_DISPLAY_VSYNC_PERIOD,
-    HWC_DISPLAY_WIDTH,
-    HWC_DISPLAY_HEIGHT,
-    HWC_DISPLAY_DPI_X,
-    HWC_DISPLAY_DPI_Y,
-    HWC_DISPLAY_NO_ATTRIBUTE,
-};
-#define NUM_DISPLAY_ATTRIBUTES (sizeof(DISPLAY_ATTRIBUTES) / sizeof(DISPLAY_ATTRIBUTES)[0])
-
-struct callbacks : public hwc_procs_t {
-       // these are here to facilitate the transition when adding
-        //         // new callbacks (an implementation can check for NULL before
-        //                 // calling a new callback).
-                     void (*zero[4])(void);
-       HwComposerBackend_v11 *hwc;
-} hwc_callbacks;
-
-void hook_invalidate(const struct hwc_procs* procs) {
-     fprintf(stderr, "=== invalidate hook called\n");
-#if 0
-     reinterpret_cast<const struct callbacks *>(procs)->hwc->invalidate();
-#endif
-}
-
-void hook_vsync(const struct hwc_procs* procs, int disp,
-        int64_t timestamp) {
-    fprintf(stderr, "=== vsync %i %i called\n", disp, timestamp);
-#if 0
-    reinterpret_cast<const struct callbacks *>(procs)->hwc->vsync(disp, timestamp);
-#endif
-}
-
-void hook_hotplug(const struct hwc_procs* procs, int disp,
-        int connected) {
-    fprintf(stderr, "=== hotplug %i %i\n", disp, connected);
-#if 0
-    reinterpret_cast<const struct callbacks *>(procs)->hwc->hotplug(disp, connected);
-#endif
-}
-
-void HwComposerBackend_v11::invalidate()
-{
-}
-
-void HwComposerBackend_v11::vsync(int disp, int64_t timestamp)
-{
-}
-
-void HwComposerBackend_v11::hotplug(int disp, int connected)
-{
-}
 
 HwComposerBackend_v11::HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, int num_displays)
     : HwComposerBackend(hwc_module)
-    , hwc_device((hwc_composer_device_1_t *)hw_device)
-    , hwc_win(NULL)
-    , hwc_list(NULL)
-    , hwc_mList(NULL)
-    , oldretire(-1)
-    , oldrelease(-1)
-    , oldrelease2(-1)
-    , num_displays(num_displays)
 {
-    int disp = 0;
-
-    hwc_callbacks.invalidate = &hook_invalidate;
-    hwc_callbacks.vsync = &hook_vsync;
-    hwc_callbacks.hotplug = &hook_hotplug;
-    hwc_callbacks.hwc = this;
-
-    hwc_device->registerProcs(hwc_device, &hwc_callbacks);
-    hwc_device->eventControl(hwc_device, HWC_DISPLAY_PRIMARY, HWC_EVENT_VSYNC, 0);
-    for (disp = 0; disp < num_displays; disp++)
-    {
-
-	    uint32_t config;
-	    int32_t values[NUM_DISPLAY_ATTRIBUTES - 1];
-	    size_t numConfigs = 1;
-	    int err = hwc_device->getDisplayConfigs(hwc_device, disp, &config, &numConfigs);
-	    if (err != 0) {
-		 fprintf(stderr, "== disp %i offline\n", disp);
-	    }
-            err = hwc_device->getDisplayAttributes(hwc_device, disp, config, DISPLAY_ATTRIBUTES, values);
-	    if (err != 0)
-            {
-                  fprintf(stderr, "== disp %i unable to get attributes\n", disp);
-	    }
-    }
-
-    sleepDisplay(false);
+    m_thread = new HWC11Thread();
+    m_thread->moveToThread(m_thread);
+    m_thread->device = (hwc_composer_device_1_t *) hw_device;
+    m_thread->post(HWC11Thread::InitializeAction);
 }
 
 HwComposerBackend_v11::~HwComposerBackend_v11()
 {
-    // Destroy the window if it hasn't yet been destroyed
-    if (hwc_win != NULL) {
-        delete hwc_win;
-    }
-
-    // Close the hwcomposer handle
-    HWC_PLUGIN_EXPECT_ZERO(hwc_close_1(hwc_device));
-
-    if (hwc_mList != NULL) {
-        free(hwc_mList);
-    }
-
-    if (hwc_list != NULL) {
-        free(hwc_list);
-    }
+    // Stop the compositor thread
+    m_thread->post(HWC11Thread::CleanupAction);
+    m_thread->quit();
+    m_thread->QThread::wait();
+    delete m_thread;
 }
 
 EGLNativeDisplayType
@@ -219,86 +163,43 @@ HwComposerBackend_v11::display()
 EGLNativeWindowType
 HwComposerBackend_v11::createWindow(int width, int height)
 {
-    // We expect that we haven't created a window already, if we had, we
-    // would leak stuff, and we want to avoid that for obvious reasons.
-    HWC_PLUGIN_EXPECT_NULL(hwc_win);
-    HWC_PLUGIN_EXPECT_NULL(hwc_list);
-    HWC_PLUGIN_EXPECT_NULL(hwc_mList);
-
-    size_t neededsize = sizeof(hwc_display_contents_1_t) + 1 * sizeof(hwc_layer_1_t);
-    hwc_list = (hwc_display_contents_1_t *) malloc(neededsize);
-    hwc_mList = (hwc_display_contents_1_t **) malloc(num_displays * sizeof(hwc_display_contents_1_t *));
-    const hwc_rect_t r = { 0, 0, width, height };
-
-    hwc_mList[0] = hwc_list;
-    for (int i = 1; i < num_displays; i++)
-	hwc_mList[i] = NULL;
-
-    hwc_layer_1_t *layer = NULL;
-
-    layer = &hwc_list->hwLayers[0];
-    memset(layer, 0, sizeof(hwc_layer_1_t));
-    layer->compositionType = HWC_FRAMEBUFFER_TARGET;
-    layer->hints = 0;
-    layer->flags = 0;
-    layer->handle = 0;
-    layer->transform = 0;
-    layer->blending = HWC_BLENDING_NONE;
-    layer->sourceCrop = r;
-#ifdef HWC_DEVICE_API_VERSION_1_3
-    layer->sourceCropf.top = 0.0f;
-    layer->sourceCropf.left = 0.0f;
-    layer->sourceCropf.bottom = (float) height;
-    layer->sourceCropf.right = (float) width;
-#endif
-    layer->displayFrame = r;
-    layer->visibleRegionScreen.numRects = 1;
-    layer->visibleRegionScreen.rects = &layer->displayFrame;
-    layer->acquireFenceFd = -1;
-    layer->releaseFenceFd = -1;
-#if (ANDROID_VERSION_MAJOR >= 4) && (ANDROID_VERSION_MINOR >= 3)
-    layer->planeAlpha = 0xff;
-#endif
-
-    hwc_list->retireFenceFd = -1;
-    hwc_list->flags = HWC_GEOMETRY_CHANGED;
-    hwc_list->numHwLayers = 1;
-
-    hwc_win = new HWComposer(width, height, HAL_PIXEL_FORMAT_RGBA_8888,
-            hwc_device, hwc_mList, &hwc_list->hwLayers[0], num_displays);
-    return (EGLNativeWindowType) static_cast<ANativeWindow *>(hwc_win);
+    qCDebug(QPA_LOG_HWC, "createWindow: %d x %d", width, height);
+    // We only support a single window
+    Q_ASSERT(!m_thread->windowSurface);
+    HWC11WindowSurface *window = new HWC11WindowSurface(width, height, HAL_PIXEL_FORMAT_RGBA_8888);
+    window->thread = m_thread;
+    m_thread->windowSurface = window;
+    m_thread->start();
+    return (EGLNativeWindowType) static_cast<ANativeWindow *>(window);
 }
 
 void
 HwComposerBackend_v11::destroyWindow(EGLNativeWindowType window)
 {
+    qCDebug(QPA_LOG_HWC, "destroyWindow");
     Q_UNUSED(window); // avoid warning in release build without the assert..
-    Q_ASSERT((HWComposer *) static_cast<ANativeWindow *>((void *)window) == hwc_win);
-    hwc_win = 0;
+    Q_ASSERT((HWC11WindowSurface *) static_cast<ANativeWindow *>((void *)window) == m_thread->windowSurface);
+
+    m_thread->lock();
+    m_thread->windowSurface = 0;
+    m_thread->unlock();
+
+    delete (HWC11WindowSurface *) static_cast<ANativeWindow *>((void *)window);
 }
 
 void
 HwComposerBackend_v11::swap(EGLNativeDisplayType display, EGLSurface surface)
 {
     // TODO: Wait for vsync?
-
-    HWC_PLUGIN_ASSERT_NOT_NULL(hwc_win);
-
+    qCDebug(QPA_LOG_HWC, "eglSwapBuffers");
     eglSwapBuffers(display, surface);
 }
 
 void
 HwComposerBackend_v11::sleepDisplay(bool sleep)
 {
-    if (sleep) {
-        HWC_PLUGIN_EXPECT_ZERO(hwc_device->blank(hwc_device, 0, 1));
-    } else {
-        HWC_PLUGIN_EXPECT_ZERO(hwc_device->blank(hwc_device, 0, 0));
-
-        if (hwc_list) {
-            hwc_list->flags |= HWC_GEOMETRY_CHANGED;
-        }
-    }
+    qCDebug(QPA_LOG_HWC, "sleep: %d", sleep);
+    m_thread->post(sleep ? HWC11Thread::DisplaySleepAction : HWC11Thread::DisplayWakeAction);
 }
 
 float
@@ -306,10 +207,219 @@ HwComposerBackend_v11::refreshRate()
 {
     // TODO: Implement new hwc 1.1 querying of vsync period per-display
     //
-    // from hwcomposer_defs.h:
+    // from HwcWindowSurface_defs.h:
     // "This query is not used for HWC_DEVICE_API_VERSION_1_1 and later.
     //  Instead, the per-display attribute HWC_DISPLAY_VSYNC_PERIOD is used."
     return 60.0;
 }
 
-#endif /* HWC_PLUGIN_HAVE_HWCOMPOSER1_API */
+
+
+static void hwc11_callback_vsync(const struct hwc_procs *, int, int64_t timestamp)
+{
+    qCDebug(QPA_LOG_HWC, "callback_vsync");
+}
+
+static void hwc11_callback_invalidate(const struct hwc_procs *)
+{
+    qCDebug(QPA_LOG_HWC, "callback_invalidate");
+}
+
+static void hwc11_callback_hotplug(const struct hwc_procs *, int, int)
+{
+    qCDebug(QPA_LOG_HWC, "callback_hotplug");
+}
+
+HWC11Thread::HWC11Thread()
+    : windowSurface(0)
+    , buffer(0)
+    , device(0)
+    , eglSurfaceList(0)
+    , frameFence(-1)
+{
+}
+
+static void hwc11_populate_layer(hwc_layer_1_t *layer, int width, int height, buffer_handle_t handle, int32_t type)
+{
+    layer->handle = handle;
+    layer->hints = 0;
+    layer->flags = 0;
+    layer->compositionType = type;
+    layer->blending = HWC_BLENDING_NONE;
+    layer->transform = 0;
+    layer->acquireFenceFd = -1;
+    layer->releaseFenceFd = -1;
+#ifdef HWC_DEVICE_API_VERSION_1_2
+    layer->planeAlpha = 0xff;
+#endif
+#ifdef HWC_DEVICE_API_VERSION_1_3
+    layer->sourceCropf.left = 0.0;
+    layer->sourceCropf.top = 0.0;
+    layer->sourceCropf.right = width;
+    layer->sourceCropf.bottom = height;
+#else
+    layer->sourceCrop.left = 0;
+    layer->sourceCrop.top = 0;
+    layer->sourceCrop.right = width;
+    layer->sourceCrop.bottom = height;
+#endif
+    layer->displayFrame.left = 0;
+    layer->displayFrame.top = 0;
+    layer->displayFrame.right = width;
+    layer->displayFrame.bottom = height;
+    layer->visibleRegionScreen.numRects = 1;
+    layer->visibleRegionScreen.rects = &layer->displayFrame;
+}
+
+void HWC11Thread::initialize()
+{
+    qCDebug(QPA_LOG_HWC, "                (RT) initialize");
+    Q_ASSERT(windowSurface);
+
+    hwc_procs *procs = new hwc_procs();
+    procs->invalidate = hwc11_callback_invalidate;
+    procs->hotplug = hwc11_callback_hotplug;
+    procs->vsync = hwc11_callback_vsync;
+    device->registerProcs(device, procs);
+    device->eventControl(device, 0, HWC_EVENT_VSYNC, 0);
+
+    int eglSurfaceListSize = sizeof(hwc_display_contents_1_t) + sizeof(hwc_layer_1_t);
+    eglSurfaceList = (hwc_display_contents_1_t *) malloc(eglSurfaceListSize);
+    memset(eglSurfaceList, 0, eglSurfaceListSize);
+    eglSurfaceList->retireFenceFd = -1;
+    eglSurfaceList->outbuf = 0;
+    eglSurfaceList->outbufAcquireFenceFd = -1;
+    eglSurfaceList->flags = HWC_GEOMETRY_CHANGED;
+    eglSurfaceList->numHwLayers = 1;
+    hwc11_populate_layer(&eglSurfaceList->hwLayers[0], windowSurface->width(), windowSurface->height(), 0, HWC_FRAMEBUFFER_TARGET);
+}
+
+void HWC11Thread::cleanup()
+{
+    free(eglSurfaceList);
+    eglSurfaceList = 0;
+    HWC_PLUGIN_EXPECT_ZERO(hwc_close_1(device));
+    device = 0;
+}
+
+struct _BufferFenceAccessor : public HWComposerNativeWindowBuffer {
+    int get() { return fenceFd; }
+    void set(int fd) { fenceFd = fd; };
+};
+static inline int hwc11_getBufferFenceFd(const HWComposerNativeWindowBuffer *b) { return ((_BufferFenceAccessor *) b)->get(); }
+static inline void hwc11_setBufferFenceFd(const HWComposerNativeWindowBuffer *b, int fd) { ((_BufferFenceAccessor *) b)->set(fd); }
+
+void HWC11Thread::swap()
+{
+    qCDebug(QPA_LOG_HWC, "                (RT) swap");
+    lock();
+
+    if (!windowSurface) {
+        // unlikely bug might happen after destroyWindow
+        qCDebug(QPA_LOG_HWC, "                (RT)  - no window surface, aborting");
+        unlock();
+        return;
+    }
+
+    Q_ASSERT(windowSurface->buffer);
+    buffer = windowSurface->buffer;
+
+    eglSurfaceList->retireFenceFd = -1;
+
+    // copy the buffer state into our list
+    hwc_layer_1_t &l = eglSurfaceList->hwLayers[0];
+    l.handle = buffer->handle;
+    l.acquireFenceFd = hwc11_getBufferFenceFd(buffer);
+    l.releaseFenceFd = -1;
+    l.hints = HWC_GEOMETRY_CHANGED;
+
+    if (QPA_LOG_HWC().isDebugEnabled()) {
+        qCDebug(QPA_LOG_HWC, "                (RT)  - %d buffers (including HWC_FRAMEBUFFER_TARGET)",  eglSurfaceList->numHwLayers);
+        qCDebug(QPA_LOG_HWC, "                (RT)  - displayContents, retireFence=%d, outbuf=%p, outAcqFence=%d, flags=%x, numLayers=%d",
+                eglSurfaceList->retireFenceFd,
+                eglSurfaceList->outbuf,
+                eglSurfaceList->outbufAcquireFenceFd,
+                (int) eglSurfaceList->flags,
+                (int) eglSurfaceList->numHwLayers);
+        qCDebug(QPA_LOG_HWC, "                (RT)    - layer comp=%x, hints=%x, flags=%x, handle=%p, transform=%x, blending=%x, "
+                "src=(%d %d - %d %d), dst=(%d %d - %d %d), afd=%d, rfd=%d, a=%d",
+                l.compositionType, l.hints, l.flags, l.handle, l.transform, l.blending,
+                (int) l.sourceCropf.left, (int) l.sourceCropf.top, (int) l.sourceCropf.right, (int) l.sourceCropf.bottom,
+                l.displayFrame.left, l.displayFrame.top, l.displayFrame.right, l.displayFrame.bottom,
+                l.acquireFenceFd, l.releaseFenceFd, l.planeAlpha);
+        for (unsigned int j=0; j<l.visibleRegionScreen.numRects; ++j) {
+            qCDebug(QPA_LOG_HWC, "                (RT)      - region (%d %d - %d %d)",
+                    l.visibleRegionScreen.rects[j].left,
+                    l.visibleRegionScreen.rects[j].top,
+                    l.visibleRegionScreen.rects[j].right,
+                    l.visibleRegionScreen.rects[j].bottom
+                   );
+        }
+    }
+
+    int prepResult = device->prepare(device, 1, &eglSurfaceList);
+    if (prepResult != 0) {
+        qDebug("prepare() failed... %x",  prepResult);
+        return;
+    }
+
+    if (QPA_LOG_HWC().isDebugEnabled()) {
+        qCDebug(QPA_LOG_HWC, "                (RT)  - after preprare:");
+        for (unsigned int i = 0; i<eglSurfaceList->numHwLayers; ++i) {
+            qCDebug(QPA_LOG_HWC, "                (RT)    - layer has composition type=%x", eglSurfaceList->hwLayers[i].compositionType);
+        }
+    }
+
+    int setResult = device->set(device, 1, &eglSurfaceList);
+    if (setResult != 0) {
+        qDebug("set() failed... %x",  setResult);
+        return;
+    }
+
+    if (frameFence != -1) {
+        sync_wait(frameFence, -1);
+        close(frameFence);
+        qCDebug(QPA_LOG_HWC, "                (RT)  --- waited");
+    }
+    frameFence = eglSurfaceList->retireFenceFd;
+    if (frameFence != -1)
+        qCDebug(QPA_LOG_HWC, "                (RT)  - frame fence: %d", frameFence);
+
+    hwc11_setBufferFenceFd(buffer, eglSurfaceList->hwLayers[0].releaseFenceFd);
+
+    eglSurfaceList->flags = 0;
+
+    windowSurface->buffer = 0;
+
+    qCDebug(QPA_LOG_HWC, "                (RT)  - composition done, waking up render thread");
+    wake();
+    unlock();
+}
+
+bool HWC11Thread::event(QEvent *e)
+{
+    qCDebug(QPA_LOG_HWC, "                (RT) action: %d", e->type());;
+    switch ((int) e->type()) {
+    case InitializeAction:
+        initialize();
+        break;
+    case CleanupAction:
+        cleanup();
+        break;
+    case BufferReadyAction:
+        swap();
+        break;
+    case DisplayWakeAction:
+        HWC_PLUGIN_EXPECT_ZERO(device->blank(device, 0, 0));
+        break;
+    case DisplaySleepAction:
+        HWC_PLUGIN_EXPECT_ZERO(device->blank(device, 0, 1));
+        break;
+    default:
+        qCDebug(QPA_LOG_HWC, "unhandled event type: %d", e->type());
+        break;
+    }
+    return QThread::event(e);
+}
+
+#endif /* HWC_PLUGIN_HAVE_HwcWindowSurface1_API */

--- a/hwcomposer/hwcomposer_backend_v11.h
+++ b/hwcomposer/hwcomposer_backend_v11.h
@@ -49,14 +49,14 @@
 // libhybris access to the native hwcomposer window
 #include <hwcomposer_window.h>
 
+class HWC11WindowSurface;
+class HWC11Thread;
+
 class HwComposerBackend_v11 : public HwComposerBackend {
 public:
     HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, int num_displays);
     virtual ~HwComposerBackend_v11();
 
-    virtual void invalidate();
-    virtual void vsync(int disp, int64_t timestamp);
-    virtual void hotplug(int disp, int connected);
     virtual EGLNativeDisplayType display();
     virtual EGLNativeWindowType createWindow(int width, int height);
     virtual void destroyWindow(EGLNativeWindowType window);
@@ -65,14 +65,7 @@ public:
     virtual float refreshRate();
 
 private:
-    hwc_composer_device_1_t *hwc_device;
-    HWComposerNativeWindow *hwc_win;
-    hwc_display_contents_1_t *hwc_list;
-    hwc_display_contents_1_t **hwc_mList;
-    int oldretire;
-    int oldrelease;
-    int oldrelease2;
-    int num_displays;
+    HWC11Thread *m_thread;
 };
 
 #endif /* HWC_PLUGIN_HAVE_HWCOMPOSER1_API */


### PR DESCRIPTION
GL rendering on hwcomposer can be divided into three separate
stages. GL draw call scheduling which is what the app is doing. Then
the GPU kicks in and rasterizes the buffer. Once the buffer is ready,
it is presented on the next vsync. In the current implementation these
were all happening in sequence on the same thread. This gives us a
very low threshold when trying to sustain 60 fps.

Instead change the implementation so we return fast from eglSwapBuffers,
allowing the application to start scheduling the next frame right away.
The hwcomposer will pick up the rendered buffer (with an acquire fence)
and scheduling the composition on a separate thread. This means that
waiting for the GPU to finish and presenting the buffer on the next vsync
happens in parallel to the application scheduling the next frame.
As the hybris hwcomposer uses 2 buffers by default, we'll allow for
a queue of one GPU rendered buffer pending display in the hwcomposer.

For an application which completes its GL scheduling quickly this
means very little, but for an application which spends 10+ms
scheduling, we now allow it to hit 60fps even if the GPU rasterization
time is close to 16ms.

This patch also introduces categorized logging into the v11 backend.