### PR TITLE
Fix building for devices using QCOM_BSP.

### DIFF
--- a/hwcomposer/hwcomposer_backend.h
+++ b/hwcomposer/hwcomposer_backend.h
@@ -44,6 +44,7 @@
 
 #include <sys/types.h>
 
+#include <android-config.h>
 #include <hardware/hardware.h>
 #include <hardware/hwcomposer.h>
 


### PR DESCRIPTION
This patch fixes graphics for devices using QCOM_BSP. Previously QCOM_BSP had to be manually added to defines in hwcomposer.pro to have working graphics. Tested on Xperia Pro (iyokan) and Xperia SP (huashan).