### PR TITLE
Qt 5.6.0 support

### DIFF
--- a/hwcomposer/hwcomposer.pro
+++ b/hwcomposer/hwcomposer.pro
@@ -57,14 +57,12 @@ SOURCES +=  $$PWD/qeglfsintegration.cpp \
             $$PWD/qeglfswindow.cpp \
             $$PWD/qeglfsbackingstore.cpp \
             $$PWD/qeglfsscreen.cpp \
-            $$PWD/qeglfscontext.cpp \
-            $$PWD/qeglfspageflipper.cpp
+            $$PWD/qeglfscontext.cpp
 
 HEADERS +=  $$PWD/qeglfsintegration.h \
             $$PWD/qeglfswindow.h \
             $$PWD/qeglfsbackingstore.h \
             $$PWD/qeglfsscreen.h \
-            $$PWD/qeglfscontext.h \
-            $$PWD/qeglfspageflipper.h
+            $$PWD/qeglfscontext.h
 
 QMAKE_LFLAGS += $$QMAKE_LFLAGS_NOUNDEF

--- a/hwcomposer/main.cpp
+++ b/hwcomposer/main.cpp
@@ -48,16 +48,15 @@ class QEglFSIntegrationPlugin : public QPlatformIntegrationPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID QPlatformIntegrationFactoryInterface_iid FILE "hwcomposer.json")
-
 public:
-    QPlatformIntegration *create(const QString&, const QStringList&);
+    QPlatformIntegration *create(const QString&, const QStringList&) Q_DECL_OVERRIDE;
 };
 
 QPlatformIntegration* QEglFSIntegrationPlugin::create(const QString& system, const QStringList& paramList)
 {
     Q_UNUSED(paramList);
-    if (system.toLower() == "hwcomposer")
-        return new QEglFSIntegration;
+    if (!system.compare(QLatin1String("hwcomposer"), Qt::CaseInsensitive))
+        return new QEglFSIntegration();
 
     return 0;
 }

--- a/hwcomposer/qeglfscontext.cpp
+++ b/hwcomposer/qeglfscontext.cpp
@@ -42,7 +42,6 @@
 #include "qeglfscontext.h"
 #include "qeglfswindow.h"
 #include "qeglfsintegration.h"
-#include "qeglfspageflipper.h"
 #include <QtPlatformSupport/private/qeglpbuffer_p.h>
 #include <QtGui/QSurface>
 #include <QtDebug>
@@ -51,7 +50,6 @@ QT_BEGIN_NAMESPACE
 
 QEglFSContext::QEglFSContext(
                                HwComposerContext *hwc
-                             , QEglFSPageFlipper *pageFlipper
                              , const QSurfaceFormat &format
                              , QPlatformOpenGLContext *share
                              , EGLDisplay display
@@ -68,7 +66,7 @@ QEglFSContext::QEglFSContext(
                         , eglApi
 #endif
       ),
-    m_hwc(hwc), m_pageFlipper(pageFlipper), m_swapIntervalConfigured(false)
+    m_hwc(hwc), m_swapIntervalConfigured(false)
 {
 }
 

--- a/hwcomposer/qeglfscontext.h
+++ b/hwcomposer/qeglfscontext.h
@@ -44,7 +44,6 @@
 
 #include <QtPlatformSupport/private/qeglconvenience_p.h>
 #include <QtPlatformSupport/private/qeglplatformcontext_p.h>
-#include "qeglfspageflipper.h"
 
 #include "hwcomposer_context.h"
 
@@ -53,7 +52,7 @@ QT_BEGIN_NAMESPACE
 class QEglFSContext : public QEGLPlatformContext
 {
 public:
-    QEglFSContext(HwComposerContext *hwc, QEglFSPageFlipper *pageFlipper,
+    QEglFSContext(HwComposerContext *hwc,
             const QSurfaceFormat &format, QPlatformOpenGLContext *share, EGLDisplay display
 #if QT_VERSION < QT_VERSION_CHECK(5, 3, 0)
             , EGLenum eglApi = EGL_OPENGL_ES_API);
@@ -65,7 +64,6 @@ public:
     void swapBuffers(QPlatformSurface *surface);
 private:
     HwComposerContext *m_hwc;
-    QEglFSPageFlipper *m_pageFlipper;
     bool m_swapIntervalConfigured;
 };
 

--- a/hwcomposer/qeglfsintegration.cpp
+++ b/hwcomposer/qeglfsintegration.cpp
@@ -63,7 +63,6 @@
 #include <qpa/qplatforminputcontextfactory_p.h>
 
 #include "qeglfscontext.h"
-#include "qeglfspageflipper.h"
 
 #include <EGL/egl.h>
 
@@ -150,7 +149,7 @@ QPlatformBackingStore *QEglFSIntegration::createPlatformBackingStore(QWindow *wi
 
 QPlatformOpenGLContext *QEglFSIntegration::createPlatformOpenGLContext(QOpenGLContext *context) const
 {
-    return new QEglFSContext(mHwc, static_cast<QEglFSPageFlipper *>(mScreen->pageFlipper()), mHwc->surfaceFormatFor(context->format()), context->shareHandle(), mDisplay);
+    return new QEglFSContext(mHwc, mHwc->surfaceFormatFor(context->format()), context->shareHandle(), mDisplay);
 }
 
 QPlatformOffscreenSurface *QEglFSIntegration::createPlatformOffscreenSurface(QOffscreenSurface *surface) const
@@ -232,11 +231,13 @@ void *QEglFSIntegration::nativeResourceForContext(const QByteArray &resource, QO
     return 0;
 }
 
-EGLConfig QEglFSIntegration::chooseConfig(EGLDisplay display, const QSurfaceFormat &format)
+EGLConfig* QEglFSIntegration::chooseConfig(EGLDisplay display, const QSurfaceFormat &format)
 {
     QEglConfigChooser chooser(display);
     chooser.setSurfaceFormat(format);
-    return chooser.chooseConfig();
+    EGLConfig config = chooser.chooseConfig();
+
+    return &config;
 }
 
 QStringList QEglFSIntegration::themeNames() const

--- a/hwcomposer/qeglfsintegration.h
+++ b/hwcomposer/qeglfsintegration.h
@@ -82,7 +82,7 @@ public:
     void *nativeResourceForContext(const QByteArray &resource, QOpenGLContext *context);
 
     QPlatformScreen *screen() const { return mScreen; }
-    static EGLConfig chooseConfig(EGLDisplay display, const QSurfaceFormat &format);
+    static EGLConfig* chooseConfig(EGLDisplay display, const QSurfaceFormat &format);
 
     EGLDisplay display() const { return mDisplay; }
 

--- a/hwcomposer/qeglfsscreen.cpp
+++ b/hwcomposer/qeglfsscreen.cpp
@@ -41,7 +41,6 @@
 
 #include "qeglfsscreen.h"
 #include "qeglfswindow.h"
-#include "qeglfspageflipper.h"
 
 #include <private/qmath_p.h>
 
@@ -49,7 +48,6 @@ QT_BEGIN_NAMESPACE
 
 QEglFSScreen::QEglFSScreen(HwComposerContext *hwc, EGLDisplay dpy)
     : m_hwc(hwc)
-    , m_pageFlipper(new QEglFSPageFlipper(this))
     , m_dpy(dpy)
 {
 #ifdef QEGL_EXTRA_DEBUG
@@ -59,16 +57,7 @@ QEglFSScreen::QEglFSScreen(HwComposerContext *hwc, EGLDisplay dpy)
 
 QEglFSScreen::~QEglFSScreen()
 {
-    delete m_pageFlipper;
 }
-
-#if 0
-QPlatformScreenPageFlipper *QEglFSScreen::pageFlipper() const
-{
-    return m_pageFlipper;
-}
-#endif
-
 
 QRect QEglFSScreen::geometry() const
 {

--- a/hwcomposer/qeglfswindow.cpp
+++ b/hwcomposer/qeglfswindow.cpp
@@ -80,7 +80,7 @@ void QEglFSWindow::create()
 
     EGLDisplay display = (static_cast<QEglFSScreen *>(window()->screen()->handle()))->display();
     QSurfaceFormat platformFormat = m_hwc->surfaceFormatFor(window()->requestedFormat());
-    m_config = QEglFSIntegration::chooseConfig(display, platformFormat);
+    m_config = *(QEglFSIntegration::chooseConfig(display, platformFormat));
     m_format = q_glFormatFromConfig(display, m_config);
     resetSurface();
 }


### PR DESCRIPTION
Support Qt 5.6.0

QPlatformScreenPageFlipper have been removed upstream so I have done some cleanup on the code about Flipper.

chooseConfig will return an EGLConfig* (to fit upstream change)

If someone else can check the code in a running device it will be great because on my device hwcomposer is not working (not specific to 5.6.0 support ;)). So this support for 5.6.0 is part of another backend project and I wanted to share it.

