### PR TITLE
[hwcomposer] Link Qt5PlatformSupport dependencies with PKGCONFIG_PRIVATE. Contributes to JB#34869.

### DIFF
--- a/hwcomposer/hwcomposer.pro
+++ b/hwcomposer/hwcomposer.pro
@@ -37,7 +37,7 @@ CONFIG += egl qpa/genericunixfontdatabase
 CONFIG += link_pkgconfig
 
 # For linking against libQt5PlatformSupport.a
-PKGCONFIG += libudev glib-2.0 mtdev
+PKGCONFIG_PRIVATE += libudev glib-2.0 mtdev
 
 # libhybris / droid integration
 PKGCONFIG += android-headers libhardware hybris-egl-platform


### PR DESCRIPTION
Otherwise, they will be linked *before* Qt5PlatformSupport, which will
fail with -Wl,--as-needed.