### PR TITLE
Avoid using Hwc::eventControl when display is off. Contributes to JB#…

### DIFF
--- a/hwcomposer/hwcomposer_backend_v11.h
+++ b/hwcomposer/hwcomposer_backend_v11.h
@@ -79,6 +79,7 @@ private:
     uint32_t hwc_version;
     int num_displays;
 
+    bool m_displayOff;
     QBasicTimer m_deliverUpdateTimeout;
     QBasicTimer m_vsyncTimeout;
     QSet<QWindow *> m_pendingUpdate;


### PR DESCRIPTION
…35911.

Calling this function when the display is off leads to
logcat errors.