### PR TITLE
Ensure the vsync thread is not running after the context is destroyed

### DIFF
--- a/hwcomposer/hwcomposer_backend_v10.cpp
+++ b/hwcomposer/hwcomposer_backend_v10.cpp
@@ -146,6 +146,8 @@ HwComposerBackend_v10::HwComposerBackend_v10(hw_module_t *hwc_module, hw_device_
 
 HwComposerBackend_v10::~HwComposerBackend_v10()
 {
+    hwc_device->eventControl(hwc_device, 0, HWC_EVENT_VSYNC, 0);
+
     // Close the hwcomposer handle
     HWC_PLUGIN_EXPECT_ZERO(hwc_close_1(hwc_device));
 

--- a/hwcomposer/hwcomposer_backend_v11.cpp
+++ b/hwcomposer/hwcomposer_backend_v11.cpp
@@ -174,6 +174,8 @@ HwComposerBackend_v11::HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_
 
 HwComposerBackend_v11::~HwComposerBackend_v11()
 {
+    hwc_device->eventControl(hwc_device, 0, HWC_EVENT_VSYNC, 0);
+
     // Close the hwcomposer handle
     if (!qgetenv("QPA_HWC_WORKAROUNDS").split(',').contains("no-close-hwc"))
         HWC_PLUGIN_EXPECT_ZERO(hwc_close_1(hwc_device));


### PR DESCRIPTION
Without this the vsync thread will stay alive after the device is
destroyed at application shutdown causing a crash.