### PR TITLE
[hwcomposer] initialize binder thread pool, add fake SurfaceFlinger service. Fixes JB#41328

### DIFF
--- a/hwcomposer/hwcomposer_backend.h
+++ b/hwcomposer/hwcomposer_backend.h
@@ -112,10 +112,11 @@ public:
     virtual bool requestUpdate(QEglFSWindow *) { return false; }
 
 protected:
-    HwComposerBackend(hw_module_t *hwc_module);
+    HwComposerBackend(hw_module_t *hwc_module, void *libmsf);
     virtual ~HwComposerBackend();
 
     hw_module_t *hwc_module;
+    void *libminisf;
 };
 
 #endif /* HWCOMPOSER_BACKEND_H */

--- a/hwcomposer/hwcomposer_backend_v0.cpp
+++ b/hwcomposer/hwcomposer_backend_v0.cpp
@@ -44,8 +44,8 @@
 #ifdef HWC_DEVICE_API_VERSION_0_1
 
 
-HwComposerBackend_v0::HwComposerBackend_v0(hw_module_t *hwc_module, hw_device_t *hw_device)
-    : HwComposerBackend(hwc_module)
+HwComposerBackend_v0::HwComposerBackend_v0(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf)
+    : HwComposerBackend(hwc_module, libminisf)
     , hwc_device((hwc_composer_device_t *)hw_device)
     , hwc_layer_list(NULL)
 {

--- a/hwcomposer/hwcomposer_backend_v0.h
+++ b/hwcomposer/hwcomposer_backend_v0.h
@@ -47,7 +47,7 @@
 
 class HwComposerBackend_v0 : public HwComposerBackend {
 public:
-    HwComposerBackend_v0(hw_module_t *hwc_module, hw_device_t *hw_device);
+    HwComposerBackend_v0(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf);
     virtual ~HwComposerBackend_v0();
 
     virtual EGLNativeDisplayType display();

--- a/hwcomposer/hwcomposer_backend_v10.cpp
+++ b/hwcomposer/hwcomposer_backend_v10.cpp
@@ -132,8 +132,8 @@ static hwc_procs_t global_procs = {
 };
 
 
-HwComposerBackend_v10::HwComposerBackend_v10(hw_module_t *hwc_module, hw_device_t *hw_device)
-    : HwComposerBackend(hwc_module)
+HwComposerBackend_v10::HwComposerBackend_v10(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf)
+    : HwComposerBackend(hwc_module, libminisf)
     , hwc_device((hwc_composer_device_1_t *)hw_device)
     , hwc_list(NULL)
     , hwc_mList(NULL)

--- a/hwcomposer/hwcomposer_backend_v10.h
+++ b/hwcomposer/hwcomposer_backend_v10.h
@@ -51,7 +51,7 @@
 
 class HwComposerBackend_v10 : public HwComposerBackend {
 public:
-    HwComposerBackend_v10(hw_module_t *hwc_module, hw_device_t *hw_device);
+    HwComposerBackend_v10(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf);
     virtual ~HwComposerBackend_v10();
 
     virtual EGLNativeDisplayType display();

--- a/hwcomposer/hwcomposer_backend_v11.cpp
+++ b/hwcomposer/hwcomposer_backend_v11.cpp
@@ -165,8 +165,8 @@ void HWComposer::present(HWComposerNativeWindowBuffer *buffer)
     }
 }
 
-HwComposerBackend_v11::HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, int num_displays)
-    : HwComposerBackend(hwc_module)
+HwComposerBackend_v11::HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf, int num_displays)
+    : HwComposerBackend(hwc_module, libminisf)
     , hwc_device((hwc_composer_device_1_t *)hw_device)
     , hwc_list(NULL)
     , hwc_mList(NULL)

--- a/hwcomposer/hwcomposer_backend_v11.h
+++ b/hwcomposer/hwcomposer_backend_v11.h
@@ -56,7 +56,7 @@ class QWindow;
 
 class HwComposerBackend_v11 : public QObject, public HwComposerBackend {
 public:
-    HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, int num_displays);
+    HwComposerBackend_v11(hw_module_t *hwc_module, hw_device_t *hw_device, void *libminisf, int num_displays);
     virtual ~HwComposerBackend_v11();
 
     virtual EGLNativeDisplayType display();


### PR DESCRIPTION
Initialize the binder thread pool by calling the startMiniSurfaceFlinger
function from libminisf.so (part of droidmedia) if available. This
avoids that binder services which are started from hwcomposer.*.so get
stuck forever.

The function also starts the fake SurfaceFlinger service if it is not
already started. This could improve performance on certain devices.