### PR TITLE
Disable vsync events on shutdown with hwc2

### DIFF
--- a/hwcomposer/hwcomposer_backend_v20.cpp
+++ b/hwcomposer/hwcomposer_backend_v20.cpp
@@ -251,7 +251,7 @@ HwComposerBackend_v20::HwComposerBackend_v20(hw_module_t *hwc_module, void *libm
 
 HwComposerBackend_v20::~HwComposerBackend_v20()
 {
-    //hwc_device->eventControl(hwc_device, 0, HWC_EVENT_VSYNC, 0);
+    hwc2_compat_display_set_vsync_enabled(hwc2_primary_display, HWC2_VSYNC_DISABLE);
 
     // Close the hwcomposer handle
     if (!qgetenv("QPA_HWC_WORKAROUNDS").split(',').contains("no-close-hwc"))


### PR DESCRIPTION
If left running its threads will continue executing code from a library
which has been unlinked.