### PR TITLE
[hwcomposer2] set display to doze mode when the HWC backend is destroyed. JB#45332

### DIFF
--- a/hwcomposer/hwcomposer_backend_v20.cpp
+++ b/hwcomposer/hwcomposer_backend_v20.cpp
@@ -246,6 +246,8 @@ HwComposerBackend_v20::~HwComposerBackend_v20()
 {
     hwc2_compat_display_set_vsync_enabled(hwc2_primary_display, HWC2_VSYNC_DISABLE);
 
+    hwc2_compat_display_set_power_mode(hwc2_primary_display, HWC2_POWER_MODE_DOZE);
+
     // Close the hwcomposer handle
     if (!qgetenv("QPA_HWC_WORKAROUNDS").split(',').contains("no-close-hwc"))
         free(hwc2_device);


### PR DESCRIPTION
In some HALs we see stray vsync events after setVsyncDisabled has been
called. Setting the display to doze mode helps. Setting display power
off also works but that would cause a flicker on bootup when e.g.
jolla-startupwizard-pre-user-session exists and jolla-startupwizard
starts.