### PR TITLE
hwcomposer: set display state to off when exiting.

### DIFF
--- a/hwcomposer/hwcomposer_backend_v20.cpp
+++ b/hwcomposer/hwcomposer_backend_v20.cpp
@@ -246,7 +246,7 @@ HwComposerBackend_v20::~HwComposerBackend_v20()
 {
     hwc2_compat_display_set_vsync_enabled(hwc2_primary_display, HWC2_VSYNC_DISABLE);
 
-    hwc2_compat_display_set_power_mode(hwc2_primary_display, HWC2_POWER_MODE_DOZE);
+    hwc2_compat_display_set_power_mode(hwc2_primary_display, HWC2_POWER_MODE_OFF);
 
     // Close the hwcomposer handle
     if (!qgetenv("QPA_HWC_WORKAROUNDS").split(',').contains("no-close-hwc"))


### PR DESCRIPTION
[hwcomposer] set display state to off when exiting. JB#52650

Without this if we exit from e.g. startupwizard and enter lipstick
some hwcomposer implementations get stuck.
This also allows us to restart lipstick without needing to restart the
hwcomposer HAL service.