### PR TITLE
hwcomposer: Fix compile errors and warnings under Qt 5.15

### DIFF
--- a/hwcomposer/qeglfsbackingstore.cpp
+++ b/hwcomposer/qeglfsbackingstore.cpp
@@ -39,6 +39,8 @@
 **
 ****************************************************************************/
 
+#include <GLES2/gl2.h>
+
 #include "qeglfsbackingstore.h"
 #include "qeglfswindow.h"
 

--- a/hwcomposer/qeglfscontext.cpp
+++ b/hwcomposer/qeglfscontext.cpp
@@ -39,9 +39,7 @@
 **
 ****************************************************************************/
 
-#include "qeglfscontext.h"
-#include "qeglfswindow.h"
-#include "qeglfsintegration.h"
+#include <QtGlobal>
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #include <QtGui/private/qeglpbuffer_p.h>
@@ -53,6 +51,10 @@
 
 #include <QtGui/QSurface>
 #include <QtDebug>
+
+#include "qeglfscontext.h"
+#include "qeglfswindow.h"
+#include "qeglfsintegration.h"
 
 QT_BEGIN_NAMESPACE
 

--- a/hwcomposer/qsystrace_selector.h
+++ b/hwcomposer/qsystrace_selector.h
@@ -45,12 +45,12 @@
 // Add dummy stub methods for QSysTrace
 namespace QSystrace
 {
-    inline void begin(const char *module, const char *tracepoint, const char *message, ...) {}
-    inline void end(const char *module, const char *tracepoint, const char *message, ...) {}
-    inline void counter(const char *module, const char *tracepoint, const char *message, ...) {}
+    inline void begin(const char */*module*/, const char */*tracepoint*/, const char */*message*/, ...) {}
+    inline void end(const char */*module*/, const char */*tracepoint*/, const char */*message*/, ...) {}
+    inline void counter(const char */*module*/, const char */*tracepoint*/, const char */*message*/, ...) {}
 };
 struct QSystraceEvent {
-    QSystraceEvent(const char *module, const char *tracepoint) {}
+    QSystraceEvent(const char */*module*/, const char */*tracepoint*/) {}
 };
 #endif
 


### PR DESCRIPTION
Fixes build errors such as the following under Qt 5.15 as observed under Void Linux:
```
qeglfsbackingstore.cpp: In member function 'virtual void QEglFSBackingStore::flush(QWindow*, const QRegion&, const QPoint&)':
qeglfsbackingstore.cpp:136:5: error: 'glEnableVertexAttribArray' was not declared in this scope
  136 |     glEnableVertexAttribArray(m_vertexCoordEntry);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
```
```
In file included from /usr/aarch64-linux-gnu/usr/include/qt5/QtCore/qobject.h:54,
                 from /usr/aarch64-linux-gnu/usr/include/qt5/QtCore/qiodevice.h:45,
                 from /usr/aarch64-linux-gnu/usr/include/qt5/QtCore/qtextstream.h:43,
                 from /usr/aarch64-linux-gnu/usr/include/qt5/QtEglSupport/5.15.2/QtEglSupport/private/qeglplatformcontext_p.h:54,
                 from qeglfscontext.h:50,
                 from qeglfscontext.cpp:42:
/usr/aarch64-linux-gnu/usr/include/qt5/QtCore/qmetatype.h:59:2: error: #error qmetatype.h must be included before any header file that defines Bool
   59 | #error qmetatype.h must be included before any header file that defines Bool
      |  ^~~~~
```
Additionally silences warnings such as these:
```
In file included from hwcomposer_backend_v11.cpp:51:
qsystrace_selector.h: In function 'void QSystrace::begin(const char*, const char*, const char*, ...)':
qsystrace_selector.h:48:35: warning: unused parameter 'module' [-Wunused-parameter]
   48 |     inline void begin(const char *module, const char *tracepoint, const char *message, ...) {}
      |                       ~~~~~~~~~~~~^~~~~~
```
Keep in mind I didn't test compile (yet) under Qt 5.6 which Sailfish OS still uses.