### PR TITLE
Add environment variable to prevent double loading and fix getting primary display if it doesn't have id 0.

### DIFF
--- a/hwcomposer/hwcomposer_backend.cpp
+++ b/hwcomposer/hwcomposer_backend.cpp
@@ -103,6 +103,13 @@ HwComposerBackend::create()
         fprintf(stderr, "libminisf is incompatible or missing. Can not possibly start the SurfaceFlinger service. If you're experiencing troubles with media try updating droidmedia (and/or this plugin).");
     }
 
+    if (!qEnvironmentVariableIsEmpty("QT_QPA_FORCE_HWC2")) {
+        // Create hwcomposer backend directly without opening hardware module
+        // because on some devices loading hwc2 module twice breaks graphics
+        // (The first load is in the composer android service.)
+        return new HwComposerBackend_v20(NULL, libminisf);
+    }
+
     // Open hardware composer
     if (hw_get_module(HWC_HARDWARE_MODULE_ID, (const hw_module_t **)(&hwc_module)) == 0) {
         fprintf(stderr, "== hwcomposer module ==\n");


### PR DESCRIPTION
Add environment variable to prevent double loading and fix getting primary display if it doesn't have id 0.