### PR TITLE
[hwcomposer] Remove unsafe async signal handler. Fixes JB#60078

### DIFF
--- a/hwcomposer/hwcomposer_context.cpp
+++ b/hwcomposer/hwcomposer_context.cpp
@@ -52,23 +52,7 @@
 
 #include <qcoreapplication.h>
 
-#include <fcntl.h>
-#include <unistd.h>
-#include <sys/ioctl.h>
-
-#include <inttypes.h>
-#include <unistd.h>
-#include <signal.h>
-
-
 QT_BEGIN_NAMESPACE
-
-
-static void exit_qt_gracefully(int sig)
-{
-    qDebug("Exiting on signal: %d", sig);
-    QCoreApplication::exit(0);
-}
 
 HwComposerContext::HwComposerContext()
     : info(NULL)
@@ -77,16 +61,6 @@ HwComposerContext::HwComposerContext()
     , window_created(false)
     , fps(0)
 {
-    // We need to catch the SIGTERM and SIGINT signals, so that we can do a
-    // proper shutdown of Qt and the plugin, and avoid crashes, hangs and
-    // reboots in cases where we don't properly close the hwcomposer.
-    struct sigaction new_action;
-    new_action.sa_handler = exit_qt_gracefully;
-    sigemptyset(&new_action.sa_mask);
-    new_action.sa_flags = 0;
-    sigaction(SIGTERM, &new_action, NULL);
-    sigaction(SIGINT, &new_action, NULL);
-
     // This actually opens the hwcomposer device
     backend = HwComposerBackend::create();
     HWC_PLUGIN_ASSERT_NOT_NULL(backend);
@@ -197,7 +171,5 @@ bool HwComposerContext::requestUpdate(QEglFSWindow *window)
         return backend->requestUpdate(window);
     return false;
 }
-
-
 
 QT_END_NAMESPACE


### PR DESCRIPTION
The exit_qt_gracefully() signal handler function is not async-signal-safe per signal-safety(7). And even if/when this does not cause immediate additional problems, the action taken - i.e. make an attempt to stop qt mainloop - makes no sense if/when qt mainloop is not (yet) running. Should an application process hang before reaching mainloop, it also effectively ignores TERM and INT signals and thus requires use of KILL signal for termination.

Do not install custom signal handlers. Leave it up to main application logic to decide whether, where and how to deal with TERM and INT signals.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>